### PR TITLE
CPLYTM-224: OSCAL Profiles sort by level - task and command (WIP)

### DIFF
--- a/trestlebot/cli/commands/sync_cac_content.py
+++ b/trestlebot/cli/commands/sync_cac_content.py
@@ -108,6 +108,7 @@ def oscal_profile_cmd(
     ctx: click.Context,
     **kwargs: Any,
 ) -> None:
+    # WIP
     # The cac_content_root accesses the repository of control files
     # User will input control file name to begin authoring OSCAL Profiles
     # If user indicates level, a profile specific to indicated level will be produced

--- a/trestlebot/cli/commands/sync_cac_content.py
+++ b/trestlebot/cli/commands/sync_cac_content.py
@@ -108,7 +108,7 @@ def oscal_profile_cmd(
     ctx: click.Context,
     **kwargs: Any,
 ) -> None:
-    # WIP
+    # WIP test
     # The cac_content_root accesses the repository of control files
     # User will input control file name to begin authoring OSCAL Profiles
     # If user indicates level, a profile specific to indicated level will be produced

--- a/trestlebot/cli/commands/sync_cac_content.py
+++ b/trestlebot/cli/commands/sync_cac_content.py
@@ -11,14 +11,16 @@ from trestlebot.cli.options.common import common_options, git_options, handle_ex
 from trestlebot.cli.utils import run_bot
 from trestlebot.tasks.authored.compdef import AuthoredComponentDefinition
 from trestlebot.tasks.base_task import TaskBase
+
+# from trestlebot.tasks.sync_cac_content_profile_task import SyncCacContentProfileTask
 from trestlebot.tasks.sync_cac_content_task import SyncCacContentTask
 
 
 logger = logging.getLogger(__name__)
 
 
-@click.command(
-    name="sync-cac-content",
+@click.group(
+    name="sync-cac-content-cmd",
     help="Transform CaC content to component definition in OSCAL.",
 )
 @click.pass_context
@@ -87,3 +89,44 @@ def sync_cac_content_cmd(ctx: click.Context, **kwargs: Any) -> None:
     pre_tasks.append(sync_cac_content_task)
 
     run_bot(pre_tasks, kwargs)
+
+
+@sync_cac_content_cmd.command(name="profile", help="Authoring Oscal Profile")
+@click.option(
+    "--cac-content-root",
+    help="Root of the CaC content project.",
+    required=True,
+)
+@click.option("--control-file", type=str, required=True, help="Name of OSCAL Profile.")
+@click.option(
+    "--filter-by-level",
+    type=str,
+    required=False,
+    help="Optionally produce OSCAL Profiles by filtered baseline level.",
+)
+def oscal_profile_cmd(
+    ctx: click.Context,
+    **kwargs: Any,
+) -> None:
+    # The cac_content_root accesses the repository of control files
+    # User will input control file name to begin authoring OSCAL Profiles
+    # If user indicates level, a profile specific to indicated level will be produced
+    # If no level associated with control file, task will create single profile with all controls
+    # pre_tasks: List[TaskBase] = []
+    #
+    # cac_content_root = kwargs["cac_content_root"]
+    # control_file = kwargs["control_file"]
+    # filter_by_level = kwargs.get("filter_by_level", None)
+    #
+    # sync_cac_content_profile_task: SyncCacContentProfileTask = (
+    #     SyncCacContentProfileTask(
+    #         working_dir=cac_content_root,
+    #         control_file=control_file,
+    #         filter_by_level=filter_by_level,
+    #     )
+    # )
+    # logger.debug(f"No levels included in control file.")
+    #
+    # pre_tasks.append(sync_cac_content_profile_task)
+    # run_bot(pre_tasks, kwargs)
+    pass


### PR DESCRIPTION
## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->
The `sync_cac_content_profile` sub-command will provide users with the ability to indicate the control file for use when authoring OSCAL profiles within trestle-bot. This PR will include a task that interacts directly with the CLI to sort the contents of the control files by level. The level indicated is included in the authored OSCAL profile title and is tailored    to the baseline level. If there is no level associated with the control file, the task will create a single profile with all controls. 

Fixes # (issue)

## Type of change

<!--Please delete options that are not relevant.-->

- [ X ] New feature (non-breaking change which adds functionality)
- [ X ] This change requires a documentation update

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
