### PR TITLE
fix: profile path resolving with profile name entry

### DIFF
--- a/docs/tutorials/sync-cac-content.md
+++ b/docs/tutorials/sync-cac-content.md
@@ -27,7 +27,7 @@ poetry run trestlebot sync-cac-content component-definition \
   --repo-path $trestlebot_workspace_directory \
   --branch main \
   --cac-content-root ~/content \
-  --cac-profile $CacContentRepo/content/products/ocp4/profiles/high-rev-4.profile \
+  --cac-profile $high-rev-4 \
   --oscal-profile $OSCAL-profile-name \
   --committer-email test@redhat.com \
   --committer-name tester \
@@ -35,7 +35,6 @@ poetry run trestlebot sync-cac-content component-definition \
   --dry-run \
   --component-definition-type $type
 ```
-
 
 For more details about these options and additional flags, you can use the --help flag:
 `poetry run trestlebot sync-cac-content component-definition --help'

--- a/tests/trestlebot/cli/test_sync_cac_content_cmd.py
+++ b/tests/trestlebot/cli/test_sync_cac_content_cmd.py
@@ -26,8 +26,7 @@ test_product = "rhel8"
 # Note: data in test_content_dir is copied from content repo, PR:
 # https://github.com/ComplianceAsCode/content/pull/12819
 test_content_dir = TEST_DATA_DIR / "content_dir"
-test_cac_profile = "products/rhel8/profiles/example.profile"
-test_cac_profiler = f"{test_content_dir}/products/{test_product}/profiles/example.profile"
+test_cac_profile = "example"
 test_prof = "simplified_nist_profile"
 test_cat = "simplified_nist_catalog"
 test_comp_path = f"component-definitions/{test_product}/component-definition.json"
@@ -267,7 +266,7 @@ def test_sync_product(tmp_repo: Tuple[str, Repo]) -> None:
             "--cac-content-root",
             test_content_dir,
             "--cac-profile",
-            test_cac_profiler,
+            test_cac_profile,
             "--oscal-profile",
             test_prof,
             "--committer-email",

--- a/tests/trestlebot/cli/test_sync_cac_content_cmd.py
+++ b/tests/trestlebot/cli/test_sync_cac_content_cmd.py
@@ -27,6 +27,7 @@ test_product = "rhel8"
 # https://github.com/ComplianceAsCode/content/pull/12819
 test_content_dir = TEST_DATA_DIR / "content_dir"
 test_cac_profile = "products/rhel8/profiles/example.profile"
+test_cac_profiler = f"{test_content_dir}/products/{test_product}/profiles/example.profile"
 test_prof = "simplified_nist_profile"
 test_cat = "simplified_nist_catalog"
 test_comp_path = f"component-definitions/{test_product}/component-definition.json"
@@ -266,7 +267,7 @@ def test_sync_product(tmp_repo: Tuple[str, Repo]) -> None:
             "--cac-content-root",
             test_content_dir,
             "--cac-profile",
-            test_cac_profile,
+            test_cac_profiler,
             "--oscal-profile",
             test_prof,
             "--committer-email",

--- a/trestlebot/cli/commands/sync_cac_content.py
+++ b/trestlebot/cli/commands/sync_cac_content.py
@@ -124,7 +124,11 @@ def sync_content_to_component_definition_cmd(ctx: click.Context, **kwargs: Any) 
     product = kwargs["product"]
     cac_content_root = kwargs["cac_content_root"]
     component_definition_type = kwargs["component_definition_type"]
-    cac_profile = os.path.join(cac_content_root, kwargs["cac_profile"])
+    # cac_profile = os.path.join(cac_content_root, kwargs["cac_profile"])
+    cac_profile = os.path.join(
+        f"{cac_content_root}/products/{product}/profiles/",
+        kwargs["cac_profile"] + ".profile",
+    )
     oscal_profile = kwargs["oscal_profile"]
     working_dir = str(kwargs["repo_path"].resolve())
 

--- a/trestlebot/cli/commands/sync_cac_content.py
+++ b/trestlebot/cli/commands/sync_cac_content.py
@@ -124,11 +124,12 @@ def sync_content_to_component_definition_cmd(ctx: click.Context, **kwargs: Any) 
     product = kwargs["product"]
     cac_content_root = kwargs["cac_content_root"]
     component_definition_type = kwargs["component_definition_type"]
-    # cac_profile = os.path.join(cac_content_root, kwargs["cac_profile"])
-    cac_profile = os.path.join(
-        f"{cac_content_root}/products/{product}/profiles/",
-        kwargs["cac_profile"] + ".profile",
-    )
+    cac_profile = kwargs["cac_profile"]
+    if not pathlib.Path(cac_profile).exists():
+        cac_profile = os.path.join(
+            f"{cac_content_root}/products/{product}/profiles/",
+            kwargs["cac_profile"] + ".profile",
+        )
     oscal_profile = kwargs["oscal_profile"]
     working_dir = str(kwargs["repo_path"].resolve())
 


### PR DESCRIPTION
## Description

This PR updates the `sync-cac-content component-definition` command for profile name entry as the `--cac-profile` flag when authoring OSCAL Component Definitions. The `--cac-profile` indicated will now be joined with the `ComplianceAsCode/content` repository path to access the profile by name.

Fixes #563

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [X] Testing through Click CLI with trestle workspace. The component-definitions are successfully created in the component-definitions directory of the trestle workspace upon command execution. 
- **The command used for testing:**

```bash

poetry run trestlebot sync-cac-content component-definition --product rhel9 
--cac-content-root ~/CaC/forked_content/content --cac-profile anssi_bp28_intermediary 
--repo-path ~/demos/tmp-trestle-demos --oscal-profile anssi-minimal 
--component-definition-type software --committer-name hbraswelrh 
--committer-email test@redhat.com --branch main --dry-run

```
- [X] GitHub Actions

**Test Configuration**:

- Firmware version: N40ET47W (1.29 )
- Hardware: Lenovo ThinkPad P1 Gen 4i
- Toolchain:
- SDK:

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
